### PR TITLE
lint coverage for outdated debug-tokens

### DIFF
--- a/src/bin/lint.sh
+++ b/src/bin/lint.sh
@@ -45,4 +45,13 @@ declare -r skippedPassing="$(make TEST_OPTS=-ps test 2>&1 | scrapePassed)"
       "$(echo "$skippedPassing - $currentPassing" | bc)"
   )"
 
+clean # before running new lint check...
+isPatternMatchOld() { grep 'Warning.*this.pattern.matching.is.not.exhaustive'; }
+makeDebugTokens() { clean && make debugtokens; }
+if ! makeDebugTokens >/dev/null 2>&1 ||
+  makeDebugTokens 2>&1 | isPatternMatchOld;then
+  recordLint \
+    'Scanner&Parser changes not shared w/debugtokens! See: `make debugtokens`'
+fi
+
 exit $lintFound


### PR DESCRIPTION
@rxie25 please [check this branch out on your macbook](https://help.github.com/articles/checking-out-pull-requests-locally/) and make sure it outputs LINT failure for you (ie: i want to be sure my script works on osx)

this fixes the problem you pointed out in slack