### PR TITLE
fixed ocamlyacc parser warming

### DIFF
--- a/src/debugtokens.ml
+++ b/src/debugtokens.ml
@@ -28,7 +28,6 @@ let stringify = function
   | NOT -> "NOT"
   | IF -> "IF"
   | ELSE -> "ELSE"
-  | ELIF -> "ELIF"
   | WHILE -> "WHILE"
   | BREAK -> "BREAK"
   | CONTINUE -> "CONTINUE"

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -7,14 +7,13 @@ open Ast
 %token SEMI LPAREN RPAREN LBRACE RBRACE COMMA COLON
 %token PLUS MINUS TIMES DIVIDE MOD POW ABS ASSIGN NOT
 %token EQ NEQ LT LEQ GT GEQ AND OR
-%token IF ELSE WHILE FIND ELIF WITH IN RANGE BREAK CONTINUE
+%token IF ELSE WHILE FIND WITH IN RANGE BREAK CONTINUE
 %token <float> LITERAL
 %token <string> ID
 %token <string> STRLIT
 %token <string> CTX
 %token EOF
 
-%nonassoc ELSE
 %right ASSIGN
 %left OR
 %left AND
@@ -22,7 +21,6 @@ open Ast
 %left LT GT LEQ GEQ
 %left PLUS MINUS
 %left TIMES DIVIDE MOD POW
-%right ABS
 %right NOT NEG
 
 %start program
@@ -166,4 +164,3 @@ actuals_opt:
 actuals_list:
     expr                    { [$1] }
   | actuals_list COMMA expr { $3 :: $1 }
-  

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -50,7 +50,6 @@ rule token = parse
 | "!"                        { NOT }
 | "if"                       { IF }
 | "else"                     { ELSE }
-| "elif"                     { ELIF }
 | "while"                    { WHILE }
 | "find"                     { FIND }
 | "break"                    { BREAK }


### PR DESCRIPTION
Warming from ```ocamlyacc parser.ml```. It won't pop when ```make```. So I missed it.
Also some junk from elif were left in there. 
It's now corrected.
```
File "parser.mly", line 25, characters 0-6:
Warning: the precedence level assigned to ABS is never useful.
File "parser.mly", line 17, characters 0-9:
Warning: the precedence level assigned to ELSE is never useful.
```