### PR TITLE
failing test to capture buggy behavior

### DIFF
--- a/src/relation.ml
+++ b/src/relation.ml
@@ -258,7 +258,7 @@ let findInitRelator (f : A.find_decl) (c : S.ctx_scopes) : (S.equation_relations
       let left : string list = List.sort String.compare originalDeps in
       let right : string list = List.sort String.compare newDeps in
 
-        left != right
+        left <> right
     in
 
     let (rangeRels, idx) =

--- a/src/tests/test-range-dependents-bug.eq
+++ b/src/tests/test-range-dependents-bug.eq
@@ -1,0 +1,7 @@
+Pendulum = {
+  magiceq = eqparam;
+}
+
+Pendulum:find magiceq with eqparam in range(5); {
+  print("magiceq: %.0f\n", magiceq);
+}

--- a/src/tests/test-range-dependents-bug.out
+++ b/src/tests/test-range-dependents-bug.out
@@ -1,0 +1,6 @@
+magiceq: 0
+magiceq: 1
+magiceq: 2
+magiceq: 3
+magiceq: 4
+magiceq: 5


### PR DESCRIPTION
fixes #103; currently we get:
```
$ ./eqeq.native < tests/test-range-dependents-bug.eq
Fatal error: exception Failure("Cyclical dependency under, "magiceq"; stopped at ID="magiceq"")
```

unblocks #102